### PR TITLE
Replace python-config with python3-config

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -54,7 +54,7 @@ then
 
   	if ! test $PYDEV
   	then
-    		for INCL in $(python-config --includes)
+    		for INCL in $(python3-config --includes)
     		do
       			echo $INCL
       			INCL=$(echo "${INCL}" | sed 's:^-I::g')


### PR DESCRIPTION
Explicit Python version 
- python-config is not standard on Debian/Ubuntu
- python3-config exists on ArchLinux
